### PR TITLE
Fix platformio lib_deps not found

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,5 +21,5 @@ lib_extra_dirs = ./lib
 ; build_flags = -D LILKA_BREADBOARD -D LILKA_NO_SPLASH
 build_flags = -D LILKA_NO_SPLASH
 extra_scripts = move_firmware.py
-lib_deps = 
-	and3rson/Lilka@^2.2.0
+lib_deps =
+	lilka/Lilka @ ^2.3.0


### PR DESCRIPTION
Looks like an oversight after main repo was moved